### PR TITLE
Add the Institute for Natural Language Processing as an institutional option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Since version 4.0.0, this project adheres to [Semantic Versioning](http://semver
 
 ## [unreleased]
 
+### Added
+- Add `Institute for Natural Language Processing` as an institute option
+
 ## [4.0.2] - 2018-06-03
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please report issues concerning this package at the GitHub repository at <https:
 
 ## Features
 
-- utf8 
+- utf8
 - options for all required text on the coverpage
 
 ## Installation
@@ -71,11 +71,12 @@ This package supports the following options:
     - `type=study` will label your work as Student Research Project
     - `type=projectinf` will label your work as Projekt-INF
     - Arbitrary strings are also possible: `type={research project}` will label your work as "research project"
-    
+
 - institute: States for which institute you are doing this work. May be set to one of the following values or arbitrary text in curly braces:
     - `institute=iaas` will state Institute of Architecture of Application Systems
     - `institute=ipvs` will state Institute of Parallel and Distributed Systems
     - `institute=fmi` will state Institute of Formal Methods in Computer Science
+    - `institute=ims` will state Institute for Natural Language Processing
     - `institute=iste` will state Institute of Software Technology
     - `institute=iti` will state Institute of Computer Architecture and Computer Engineering
     - `institute=iris` will state Institute of Computer-aided Product Development Systems
@@ -93,7 +94,7 @@ This package supports the following options:
     - `course=simtech` will state that your course of study is Simulation Technology
     - Arbitrary strings are possible: `course={New Study course}` will state that your course of study is New Study course
 
-- examiner: Your examiner. 
+- examiner: Your examiner.
     - `examiner={Prof.\ Dr.\ Hans Mustermann}`
 
 - supervisor: Your supervisor.

--- a/scientific-thesis-cover.sty
+++ b/scientific-thesis-cover.sty
@@ -103,7 +103,7 @@
     \gdef\@labeliaas{Institute of Architecture of Application Systems}%
     \gdef\@labelipvs{Institute of Parallel and Distributed Systems}%
     \gdef\@labelfmi{Institute of Formal Methods in Computer Science}%
-    \gdef\@labeliste{Institute for Natural Language Processing}%
+    \gdef\@labelims{Institute for Natural Language Processing}%
     \gdef\@labeliste{Institute of Software Technology}%
     \gdef\@labeliti{Institute of Computer Architecture and Computer Engineering}%
     \gdef\@labeliris{Institute of Computer-aided Product Development Systems}%

--- a/scientific-thesis-cover.sty
+++ b/scientific-thesis-cover.sty
@@ -103,6 +103,7 @@
     \gdef\@labeliaas{Institute of Architecture of Application Systems}%
     \gdef\@labelipvs{Institute of Parallel and Distributed Systems}%
     \gdef\@labelfmi{Institute of Formal Methods in Computer Science}%
+    \gdef\@labeliste{Institute for Natural Language Processing}%
     \gdef\@labeliste{Institute of Software Technology}%
     \gdef\@labeliti{Institute of Computer Architecture and Computer Engineering}%
     \gdef\@labeliris{Institute of Computer-aided Product Development Systems}%
@@ -150,6 +151,7 @@
     \gdef\@labeliaas{Institut für Architektur von Anwendungssystemen}%
     \gdef\@labelipvs{Institut für Parallele und Verteilte Systeme}%
     \gdef\@labelfmi{Institut für Formale Methoden der Informatik}%
+    \gdef\@labelims{Institut für Maschinelle Sprachverarbeitung}%
     \gdef\@labeliste{Institut für Softwaretechnologie}%
     \gdef\@labeliti{Institut für Technische Informatik}%
     \gdef\@labeliris{Institut für Rechnergestützte Ingenieursysteme}%


### PR DESCRIPTION
As the title suggests, this PR complements the IMS as an institutional option.
It also removes some trailing spaces.

- [X] Change in CHANGELOG.md described