### PR TITLE
add document affirmations for multiple authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Since version 4.0.0, this project adheres to [Semantic Versioning](http://semver
 
 ### Added
 - Add `Institute for Natural Language Processing` as an institute option
+- Add document confirmations for multiple authors
 
 ## [4.0.2] - 2018-06-03
 

--- a/scientific-thesis-cover.sty
+++ b/scientific-thesis-cover.sty
@@ -372,8 +372,9 @@
 
 \newcommand{\Versicherung}{
     \cleardoublepage
-    \newcommand{\USCCover@isTwoColumn}{false}
-    \if@twocolumn \renewcommand{\USCCover@isTwoColumn}{true} \onecolumn \fi
+    \providecommand{\USCCover@isTwoColumn}{}
+    \if@twocolumn \renewcommand{\USCCover@isTwoColumn}{true} \onecolumn
+        \else \renewcommand{\USCCover@isTwoColumn}{false} \fi
     \null
     \vskip 5cm\relax
     \begin{center}
@@ -390,7 +391,7 @@
         \end{minipage}
     \end{center}
     \clearpage
-    \newcommand{\USCCover@true}{true}
+    \providecommand{\USCCover@true}{true}
     \ifthenelse{\equal{\USCCover@isTwoColumn}{\USCCover@true}}{\twocolumn}{}
 }
 \newcommand{\Affirmation}{\Versicherung}


### PR DESCRIPTION
Fixing #19 

Now it is possible to use `\Affirmation` multiple times.
I use `\providecommand` to make sure the command exists, and then renew it with `\renewcommand` with the desired value..