### PR TITLE
Added VISUS as an institute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Since version 4.0.0, this project adheres to [Semantic Versioning](http://semver
 ### Added
 - Add `Institute for Natural Language Processing` as an institute option
 - Add document confirmations for multiple authors
+- Added VISUS as an institute.
 
 ## [4.0.2] - 2018-06-03
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This package supports the following options:
     - `institute=iti` will state Institute of Computer Architecture and Computer Engineering
     - `institute=iris` will state Institute of Computer-aided Product Development Systems
     - `institute=vis` will state Institute of Visualization and Interactive Systems
+    - `institute=visus` will state Visualization Research Center (VISUS)
     - `institute=sec` will state Institute of Information Security
     - `institute=fac` will state Faculty of Computer Science
     - Arbitrary strings are possible: `institute={Custom fictional institute}` will state Custom fictional institute
@@ -160,7 +161,7 @@ In case files are not listed here, but available at <https://github.com/latextem
 
 ### Contributors (incomplete list)
 
-Bernd Raichle, Timo Heiber, Steffen Keul, Oliver Kopp, Kai Mindermann, Matthias Papesch, Nils Radtke, Niklas Schnelle
+Bernd Raichle, Timo Heiber, Steffen Keul, Oliver Kopp, Kai Mindermann, Matthias Papesch, Nils Radtke, Niklas Schnelle, Tim Halach
 
   [computer science institutes of the University of Stuttgart]: http://www.informatik.uni-stuttgart.de/index.en.html
   [INFOTECH]: https://www.uni-stuttgart.de/infotech/

--- a/scientific-thesis-cover.sty
+++ b/scientific-thesis-cover.sty
@@ -108,6 +108,7 @@
     \gdef\@labeliti{Institute of Computer Architecture and Computer Engineering}%
     \gdef\@labeliris{Institute of Computer-aided Product Development Systems}%
     \gdef\@labelvis{Institute for Visualization and Interactive Systems}%
+    \gdef\@labelvisus{Visualization Research Center (VISUS)}%
     \gdef\@labelsec{Institute of Information Security}%
 
     \gdef\@labelAffirmation{Declaration}%
@@ -156,6 +157,7 @@
     \gdef\@labeliti{Institut für Technische Informatik}%
     \gdef\@labeliris{Institut für Rechnergestützte Ingenieursysteme}%
     \gdef\@labelvis{Institut für Visualisierung und Interaktive Systeme}%
+    \gdef\@labelvisus{Visualisierungsinstitut der Universität Stuttgart (VISUS)}%
     \gdef\@labelsec{Institut für Informationssicherheit}%
 
     \gdef\@labelAffirmation{Erklärung}%
@@ -214,6 +216,7 @@
     \def\0{iti}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelInstitute{\@labeliti\\\@labelUniversity\\Pfaffenwaldring 47\\D--70569 Stuttgart}}{}
     \def\0{iris}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelInstitute{\@labeliris\\\@labelAddress}}{}
     \def\0{vis}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelInstitute{\@labelvis\\\@labelAddress}}{}
+    \def\0{visus}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelInstitute{\@labelvisus\\\@labelUniversity\\Allmandring 19\\D--70569 Stuttgart}}{}
     \def\0{sec}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelInstitute{\@labelsec\\\@labelAddress}}{}
     \def\0{fac}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelInstitute{\@labelDept\\\@labelAddress}}{}
 }


### PR DESCRIPTION
This adds the VISUS (Visualization Research Center/Visualisierungsinstitut der Universität Stuttgart) as a selectable institute.

- [x] Change in CHANGELOG.md described
