### PR TITLE
Added logo to coverpage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Since version 4.0.0, this project adheres to [Semantic Versioning](http://semver
 - Add `Institute for Natural Language Processing` as an institute option
 - Add document confirmations for multiple authors
 - Added VISUS as an institute.
+- Added the ability to add a logo at the top of the coverpage.
 
 ## Fixed
 - Fix `ß` being displayed as `SS` in `Universitätsstraße`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Just include the package with all options specified:
         supervisor={Otto Normalverbraucher, M.Sc.},
         startdate={2012-06-01},
         enddate={2012-12-01},
-        language=english
+        language=english,
+        logo={unilogo}
     ]{scientific-thesis-cover}
 
 Afterwards you can create the cover using `\Coverpage` and get the affirmation text by using `\Affirmation`
@@ -116,6 +117,8 @@ This package supports the following options:
 
 - number: Running number of work. May contain arbitrary text. Should contain the number you got for your work.
     - `number=1234` will label your work to have number 1234
+- logo: Adds a logo, e.g. of your university, at the top of the coverpage.
+    - The image's path can not contain any underscores!
 - `setPageNumberToOne=true` will set the page after the cover to `1` (default false)
 - `setCoverPageNumberToMinusOne=true` will set `-1` as the page number for the cover page (default false)
 

--- a/demo.tex
+++ b/demo.tex
@@ -1,5 +1,6 @@
 \documentclass[oneside]{article}
 \usepackage[utf8]{inputenc}
+\usepackage{mwe}
 \usepackage[
 	title={Super relevant evaluation of new blackhole-generation method},
 	author={Max Musterjunge},
@@ -11,7 +12,8 @@
 	supervisor={Otto Normalverbraucher\ M.Sc.},
 	startdate={2012-06-01},
 	enddate={2012-12-01},
-	language=english
+	language=english,
+	logo={example-image-16x9.pdf}
 	]{scientific-thesis-cover}
 \begin{document}
 \Coverpage

--- a/scientific-thesis-cover.sty
+++ b/scientific-thesis-cover.sty
@@ -52,6 +52,7 @@
 \DeclareStringOption[supervisor not set]{supervisor}
 \DeclareStringOption[startdate not set]{startdate}
 \DeclareStringOption[enddate not set]{enddate}
+\DeclareStringOption[]{logo}
 \DeclareStringOption[standard]{covertype} % type of the coverpage: standard, ustuttdiss
 
 \DeclareStringOption[german]{language}
@@ -265,6 +266,11 @@
         \rightmargin 20mm \let\makelabel\USCCover@TBlabel}%
 }{\endlist}
 
+% Only include package if a logo is provided, otherwise it is not needed.
+\ifx\MCS@logo\empty
+\else
+    \usepackage{graphicx}
+\fi
 % ------------------------------
 % usable commands
 % ------------------------------
@@ -311,7 +317,21 @@
 
                 \vskip 20mm\relax %%%
 
-                \vbox to 70mm{
+                % Height of the institute vbox
+                \newcommand{\instituteHeight}{70}
+
+                \ifx\MCS@logo\empty
+                \else
+                    \vbox to 15mm{
+                        \begin{center}
+                            \includegraphics[height=14mm]{\MCS@logo}
+                        \end{center}
+                       \vfill}
+                    % Height of institute vbox reduced to accomodate logo
+                    \renewcommand{\instituteHeight}{55}
+                \fi
+
+                \vbox to \instituteHeight mm{
                         \begin{center}%
                             \@labelInstitute
                         \end{center}


### PR DESCRIPTION
Added the ability to add a logo at the very top of the coverpage.

## Changes
Adding the logo is optional. If a logo is added the institute is moved down a bit but nothing else. If no logo is added the institute remains were it was before this change.

`demo.txt` was updated to show this is an option now. For this the logo of the University of Stuttgart is now included in the repo.

## Reasons
This change was done to make this template conform to the [layout requirements](https://www.f05.uni-stuttgart.de/en/cs/students/thesis/) of the CS faculty of the University of Stuttgart. The logo is made optional as to not interfere with other institutions using this template.

## Points to consider
- The `graphicx` package is only included if a logo is specified.
- The image's path can not contain any underscores because `kvoptions` interprets them as `Ω_` if they are escaped or as the LaTeX subscript operator if they are not escaped.

---

- [x] Change in CHANGELOG.md described
