### PR TITLE
Fixed address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Since version 4.0.0, this project adheres to [Semantic Versioning](http://semver
 - Add `Institute for Natural Language Processing` as an institute option
 - Add document confirmations for multiple authors
 
+## Fixed
+- Fix `ß` being displayed as `SS` in `Universitätsstraße`.
+
 ## [4.0.2] - 2018-06-03
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ In case files are not listed here, but available at <https://github.com/latextem
 
 ### Contributors (incomplete list)
 
-Bernd Raichle, Timo Heiber, Steffen Keul, Oliver Kopp, Kai Mindermann, Matthias Papesch, Nils Radtke, Niklas Schnelle
+Bernd Raichle, Timo Heiber, Steffen Keul, Oliver Kopp, Kai Mindermann, Matthias Papesch, Nils Radtke, Niklas Schnelle, Tim Halach
 
   [computer science institutes of the University of Stuttgart]: http://www.informatik.uni-stuttgart.de/index.en.html
   [INFOTECH]: https://www.uni-stuttgart.de/infotech/

--- a/scientific-thesis-cover.sty
+++ b/scientific-thesis-cover.sty
@@ -198,7 +198,7 @@
 % ------------------------------
 
 % general university address
-\gdef\@labelAddress{\@labelUniversity\\Universitätsstraße 38\\D--70569 Stuttgart}
+\gdef\@labelAddress{\@labelUniversity\\Universitätsstra{\ss}e 38\\D--70569 Stuttgart}
 
 \newcommand{\USCCover@setInstitute}{
     % use specified text if institute does not match


### PR DESCRIPTION
Fixed `Universitätsstraße` being displayed as `UniversitätsstraSSe`.

- [x] Change in CHANGELOG.md described
