### PR TITLE
Update affirmation text

### DIFF
--- a/scientific-thesis-cover.sty
+++ b/scientific-thesis-cover.sty
@@ -112,12 +112,12 @@
     \gdef\@labelsec{Institute of Information Security}%
 
     \gdef\@labelAffirmation{Declaration}%
-    \gdef\@AffirmationText{I hereby declare that the work presented in this thesis is entirely my own and that
+    \gdef\@AffirmationText{I hereby declare that the work presented in this thesis is entirely my own.
         I did not use any other sources and references than the listed ones.
         I have marked all direct or indirect statements from other sources contained therein as quotations.
         Neither this work nor significant parts of it were part of another examination procedure.
         I have not published this work in whole or in part before.
-        The electronic copy is consistent with all submitted copies.
+        The electronic copy is consistent with all submitted hard copies.
     }
     \gdef\@labelSignature{\ place, date, signature}
 }
@@ -166,7 +166,7 @@
         Ich habe keine anderen als die angegebenen Quellen benutzt und alle wörtlich oder sinngemäß aus anderen Werken übernommene Aussagen als solche gekennzeichnet.
         Weder diese Arbeit noch wesentliche Teile daraus waren bisher Gegenstand eines anderen Prüfungsverfahrens.
         Ich habe diese Arbeit bisher weder teilweise noch vollständig veröffentlicht.
-        Das elektronische Exemplar stimmt mit allen eingereichten Exemplaren überein.
+        Das elektronische Exemplar stimmt mit allen eingereichten Druck-Exemplaren überein.
     }
     \gdef\@labelSignature{\ Ort, Datum, Unterschrift}
 }


### PR DESCRIPTION
In the [template for the affirmation text](https://www.f05.uni-stuttgart.de/informatik/dokumente/Formulare/PersoenlicheErklaerung.pdf) of the University of Stuttgart, the wording in the last sentence was changed from "copies" to "hard copies".

I'm not sure if this change is worth mentioning in CHANGELOG.md.