### PR TITLE
Fix English name for IPVS

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This package supports the following options:
 
 - institute: States for which institute you are doing this work. May be set to one of the following values or arbitrary text in curly braces:
     - `institute=iaas` will state Institute of Architecture of Application Systems
-    - `institute=ipvs` will state Institute of Parallel and Distributed Systems
+    - `institute=ipvs` will state Institute for Parallel and Distributed Systems
     - `institute=fmi` will state Institute of Formal Methods in Computer Science
     - `institute=ims` will state Institute for Natural Language Processing
     - `institute=iste` will state Institute of Software Engineering

--- a/scientific-thesis-cover.sty
+++ b/scientific-thesis-cover.sty
@@ -101,7 +101,7 @@
 
     % institute names
     \gdef\@labeliaas{Institute of Architecture of Application Systems}%
-    \gdef\@labelipvs{Institute of Parallel and Distributed Systems}%
+    \gdef\@labelipvs{Institute for Parallel and Distributed Systems}%
     \gdef\@labelfmi{Institute of Formal Methods in Computer Science}%
     \gdef\@labelims{Institute for Natural Language Processing}%
     \gdef\@labeliste{Institute of Software Engineering}%


### PR DESCRIPTION
The IPVS at University of Stuttgart has the full English name "Institute **for** Parallel and Distributed Systems" and not
"Institute **of** Parallel and Distributed Systems".

Source: https://www.ipvs.uni-stuttgart.de/
